### PR TITLE
home: Add explicit value to flex prop to avoid application crash on Android

### DIFF
--- a/home/screens/Dashboard.js
+++ b/home/screens/Dashboard.js
@@ -32,7 +32,7 @@ class Dashboard extends Component {
             <Text h1>34</Text>
             <Text h1 size={34} height={80} weight='600' spacing={0.1}>°C</Text>
           </Block>
-          <Block flex column>
+          <Block flex={1} column>
             <Text caption>Humidity</Text>
             <LineChart
               yMax={100}

--- a/home/screens/Settings.js
+++ b/home/screens/Settings.js
@@ -53,11 +53,11 @@ class Settings extends Component {
             </Block>
             <Text caption>Temperature</Text>
           </Block>
-          <Block flex center>
+          <Block flex={1} center>
             <PanSlider />
           </Block>
         </Block>
-        <Block flex style={{ paddingTop: theme.sizes.base * 2 }}>
+        <Block flex={1} style={{ paddingTop: theme.sizes.base * 2 }}>
           <Block column style={{ marginVertical: theme.sizes.base * 2 }}>
             <Block row space="between">
               <Text welcome color="black">Direction</Text>


### PR DESCRIPTION
If the prop _flex_ does not have an explicit value, the condition [flex && { flex }](https://github.com/react-ui-kit/dribbble2react/blob/70d2ef52a1c475f213077559b135faf923700d72/home/components/Block.js#L9) is equal to true and the application crashes (boolean cannot be cast to double).